### PR TITLE
[493870] Propagate ThreadDeath to threads waiting for RunnableLock

### DIFF
--- a/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/Synchronizer.java
+++ b/bundles/org.eclipse.rap.rwt/src/org/eclipse/swt/widgets/Synchronizer.java
@@ -179,6 +179,7 @@ boolean runAsyncMessages (boolean all) {
 			try {
 				lock.run ();
 			}	catch( ThreadDeath t ) {
+				lock.throwable = t;
         // Don't trap ThreadDeath, see bug 284202
         throw t;
 			} catch (Throwable t) {


### PR DESCRIPTION
Threads waiting for the RunnableLock need to get informed about closing
the UIThread. 

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=493870
Signed-off-by: Wojtek Polcwiartek <wojciech.polcwiartek@tolina.de>